### PR TITLE
fix for php 5.6 and above.

### DIFF
--- a/interface.php
+++ b/interface.php
@@ -70,7 +70,7 @@ class wechatCallbackapi{
     						<MsgId>1234567890123456</MsgId>
     						</xml>";
 		}else{
-			$postStr = $GLOBALS["HTTP_RAW_POST_DATA"];
+			$postStr = file_get_contents('php://input');
 		}
 
     //extract post data


### PR DESCRIPTION
Hi man, 

I installed your plugin and find it is not working with my PHP 7 setup. 

So with some debug process and finally find here: http://php.net/manual/zh/reserved.variables.httprawpostdata.php

the HTTP_RAW_POST_DATA is deprecated sicne php 5.6

This fix works for me. Please review.